### PR TITLE
Change people modal and add loader

### DIFF
--- a/client/src/components/menu/Mail.js
+++ b/client/src/components/menu/Mail.js
@@ -1,20 +1,14 @@
-import React, { Component } from 'react';
-import Axios from 'axios';
-import API from '../../util/api';
-import ReactTable from 'react-table';
-import 'react-table/react-table.css';
+import React, { Component } from 'react'
+import Axios from 'axios'
+import API from '../../util/api'
+import Loader from '../../util/Loader'
+import ReactTable from 'react-table'
+import 'react-table/react-table.css'
 import {
   Container,
   Grid,
-  Modal,
-  Divider,
-  Checkbox,
-  Table,
-  Form,
-  Dropdown,
-  Button,
-  Breadcrumb
-} from 'semantic-ui-react';
+  Button
+} from 'semantic-ui-react'
 
 export default class Mail extends Component {
   state = {
@@ -32,12 +26,12 @@ export default class Mail extends Component {
     // peopleData: [],
     clickedData: [],
     mail: `안녕하세요 ㅇㅇㅇ 님, 어제 제안드렸던 Position 에 대해서 어떻게 생각해보셨는지 문의차 다시 메일 드립니다. 간략히 검토후 의향에 대해서 회신 주시면 감사하겠습니다. ㅇㅇㅇ 드림`
-  };
+  }
 
   _renderTable() {
-    const { peopleData } = this.state;
+    const { peopleData } = this.state
 
-    console.log('clicked', this.state.clickedData);
+    console.log('clicked', this.state.clickedData)
     return (
       <ReactTable
         data={peopleData}
@@ -48,9 +42,9 @@ export default class Mail extends Component {
               textAlign: 'center'
             },
             onClick: () => {
-              this.setState({ clickedData: rowInfo.original });
+              this.setState({ clickedData: rowInfo.original })
             }
-          };
+          }
         }}
         columns={[
           {
@@ -95,13 +89,13 @@ export default class Mail extends Component {
         defaultPageSize={15}
         className="-striped -highlight"
       />
-    );
+    )
   }
 
   async componentDidMount() {
     this.setState({
       loading: true
-    });
+    })
     await Axios.post(API.mainTable, {
       // 제대로 된 API 주소 나오면 변경해야 함.
       under_age: 0,
@@ -113,23 +107,25 @@ export default class Mail extends Component {
         this.setState({
           // peopleData: res.data.result,
           loading: false
-        });
+        })
       })
       .catch(err => {
-        console.log(err.response);
-      });
+        console.log(err.response)
+      })
   }
   render() {
-    const { loading } = this.state;
+    const { loading } = this.state
 
     return loading ? (
-      <div>people loading</div>
+      <Loader />
     ) : (
       <Container>
         <Grid.Row>
           <Grid.Column width={13}>
-          <Button compact mini floated='right' color='teal'>
-          Follow Up
+          <Button 
+            compact mini floated='right' color='teal'
+            icon='mail' content='Follow Up'
+            >
           </Button>
           </Grid.Column>
         </Grid.Row>
@@ -138,6 +134,6 @@ export default class Mail extends Component {
         <br />
         {this._renderTable()}
       </Container>
-    );
+    )
   }
 }

--- a/client/src/components/menu/Mail.js
+++ b/client/src/components/menu/Mail.js
@@ -128,24 +128,9 @@ export default class Mail extends Component {
       <Container>
         <Grid.Row>
           <Grid.Column width={13}>
-            <Breadcrumb>
-              {/* mail/sms 이동하는 별도의 메뉴 */}
-              <Breadcrumb.Section link active>
-                Mail
-              </Breadcrumb.Section>
-              <Breadcrumb.Divider>|</Breadcrumb.Divider>
-              <Breadcrumb.Section link>SMS</Breadcrumb.Section>
-              <Breadcrumb.Divider>|</Breadcrumb.Divider>
-            </Breadcrumb>
-          </Grid.Column>
-          <Grid.Column width={3}>
-            <Breadcrumb>
-              <Breadcrumb.Section link>Follow up</Breadcrumb.Section>
-              <Breadcrumb.Divider>|</Breadcrumb.Divider>
-              <Breadcrumb.Section>
-                <a href="/">새로운 메일</a>
-              </Breadcrumb.Section>
-            </Breadcrumb>
+          <Button compact mini floated='right' color='teal'>
+          Follow Up
+          </Button>
           </Grid.Column>
         </Grid.Row>
 

--- a/client/src/components/menu/People.js
+++ b/client/src/components/menu/People.js
@@ -254,24 +254,25 @@ export default class People extends Component {
       <Container>
         <Form>
           <Form.Group inline>
-            <Form.Input placeholder='25세' width={2} />
-            <Form.Input placeholder='35세' width={2} />
+            <Form.Input placeholder='25세' width={2} size='mini' />
+            <Form.Input placeholder='35세' width={2} size='mini' />
             <Form.Checkbox label='Top School' />
           </Form.Group>
           <Form.Group>
-            <Form.Input placeholder='검색어 (And, Or)' width={4}/>
-            <Form.Button>Search</Form.Button>
+            <Form.Input placeholder='검색어 (And, Or)' width={4} size='mini' />
+            <Form.Button compact mini>Search</Form.Button>
           </Form.Group>
           <br></br>
           <br></br>
         </Form>
         <Dropdown
-          placeholder='Position' fluid selection
+          placeholder='Position'
+          fluid multiple selection compact
           options={this.positionOptions}
-          style={{maxWidth:'20em'}}
+          style={{minWidth:'10em', maxWidth:'25em'}}
           >
         </Dropdown>
-        <Button.Group inline>
+        <Button.Group inline compact mini>
           <this.MailModal />
           <Button.Or />
           <this.SMSModal />

--- a/client/src/components/menu/People.js
+++ b/client/src/components/menu/People.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react'
 import Axios from 'axios'
 import API from '../../util/api'
+import Loader from '../../util/Loader'
 import ReactTable from 'react-table'
 import 'react-table/react-table.css'
+import './menu.css'
 import {
   Container, Grid, Modal, 
   Divider, Checkbox, Table, Form, Dropdown, Button } from 'semantic-ui-react'
@@ -11,16 +13,20 @@ export default class People extends Component {
   state = {
     loading: false,
     peopleData: [],
+    clicked: false,
     clickedData: [],
-    mail: 
-      `안녕하세요 ㅇㅇㅇ 님, 어제 제안드렸던 Position 에 대해서 어떻게 생각해보셨는지 문의차 다시 메일 드립니다. 간략히 검토후 의향에 대해서 회신 주시면 감사하겠습니다. ㅇㅇㅇ 드림`,
-    sms: 
-      `안녕하세요 ㅇㅇㅇ 님, 어제 제안드렸던 Position 에 대해서 어떻게 생각해보셨는지 문의차 다시 메일 드립니다. 간략히 검토후 의향에 대해서 회신 주시면 감사하겠습니다. ㅇㅇㅇ 드림`,
-
+    isOpen: false,
   }
 
+  _openModal = () => this.setState({ isOpen: true })
+  _closeModal = () => this.setState({ isOpen: !this.state.isOpen })
+
   PeopleModal = () => (
-    <Modal trigger={<Checkbox />}>
+    <Modal
+      open={this.state.isOpen}
+      onClose={this._closeModal}
+      closeOnDimmerClick={false}
+      >
       <Modal.Header>{this.state.clickedData.name}</Modal.Header>
       <Modal.Content>
         <Grid padded>
@@ -80,17 +86,25 @@ export default class People extends Component {
           </Grid.Row>
         </Grid>
       </Modal.Content>
+      <Modal.Actions>
+        <Button
+          onClick={this._closeModal}
+          color='teal'
+          icon='checkmark'
+          content='Close'
+        ></Button>
+      </Modal.Actions>
     </Modal>
   )
 
   MailModal = () => (
     <Modal trigger={<Button>Mail</Button>}>
-      <Modal.Header>Mail: OOO</Modal.Header>
+      <Modal.Header>Mail: {this.state.clickedData.name}</Modal.Header>
       <Modal.Content>
         <Form>
           <Form.TextArea
             autoHeight
-            value={this.state.mail}
+            value={`안녕하세요 ${this.state.clickedData.name} 님, 어제 제안드렸던 Position 에 대해서 어떻게 생각해보셨는지 문의차 다시 메일 드립니다. 간략히 검토후 의향에 대해서 회신 주시면 감사하겠습니다. ㅇㅇㅇ 드림`}
             onChange={this._handleMailTextChange}
           />
           <Form.Button>Send</Form.Button>
@@ -110,12 +124,12 @@ export default class People extends Component {
 
   SMSModal = () => (
     <Modal trigger={<Button>SMS</Button>}>
-      <Modal.Header>SMS: </Modal.Header>
+      <Modal.Header>SMS: {this.state.clickedData.name} </Modal.Header>
       <Modal.Content>
         <Form>
         <Form.TextArea
             autoHeight
-            value={this.state.sms}
+            value={`안녕하세요 ${this.state.clickedData.name} 님, 어제 제안드렸던 Position 에 대해서 어떻게 생각해보셨는지 문의차 다시 메일 드립니다. 간략히 검토후 의향에 대해서 회신 주시면 감사하겠습니다. ㅇㅇㅇ 드림`}
             onChange={this._handleSMSTextChange}
           />
           <Form.Button>Send</Form.Button>
@@ -128,8 +142,7 @@ export default class People extends Component {
     this.setState({sms: event.target.value})
   }
 
-  _handleSMSSubmit = (event) => {
-    // add SMS api
+  _handleSMSSubmit = (event) => { // add SMS api
     event.preventDefault()
   }
 
@@ -146,7 +159,7 @@ export default class People extends Component {
 
   _renderTable() {
     const { peopleData } = this.state
-    console.log('clicked', this.state.clickedData)
+
     return (
       <ReactTable
         data={peopleData}
@@ -157,7 +170,7 @@ export default class People extends Component {
               textAlign: 'center'
             },
             onClick: () => {
-              this.setState({clickedData: rowInfo.original})
+              this.setState({clickedData: rowInfo.original, clicked: true})
             }
           }
         }}
@@ -167,12 +180,12 @@ export default class People extends Component {
               {
                 Header: 'Checkbox',
                 accessor: 'Checkbox',
-                Cell: props => <this.PeopleModal />
+                Cell: <Checkbox />
               },
               {
                 Header: '이름',
                 accessor: 'name',
-                Cell: props => <span>{props.value}</span>
+                Cell: props => <span onClick={this._openModal}>{props.value}</span>
               },
               {
                 Header: '나이',
@@ -183,7 +196,6 @@ export default class People extends Component {
                 Header: '최종학력',
                 accessor: 'school',
                 Cell: props => <span>{props.value}</span>
-                // Cell: props => <span>{props.value}</span>
               },
               {
                 Header: '주요직장',
@@ -245,40 +257,53 @@ export default class People extends Component {
       })
   }
 
+  MainPage = () => (
+    <div>
+      <Form>
+        <Form.Group inline>
+          <Form.Input placeholder='25세' width={2} size='mini' />
+          <Form.Input placeholder='35세' width={2} size='mini' />
+          <Form.Checkbox label='Top School' />
+        </Form.Group>
+        <Form.Group>
+          <Form.Input placeholder='검색어 (And, Or)' width={4} size='mini' />
+          <Form.Button compact mini>Search</Form.Button>
+        </Form.Group>
+        <br></br>
+        <br></br>
+      </Form>
+      <Dropdown
+        placeholder='Position'
+        fluid multiple selection compact
+        options={this.positionOptions}
+        style={{minWidth:'10em', maxWidth:'25em'}}
+        >
+      </Dropdown>
+      <Button.Group inline compact mini>
+        <this.MailModal />
+        <Button.Or />
+        <this.SMSModal />
+      </Button.Group>
+      <br></br>
+    </div>
+  )
+
   render() {
     const { loading } = this.state
+    console.log(this.state)
 
     return loading ? (
-      <div>people loading</div>
+      <Container>
+        <this.MainPage />
+        <br></br>
+        <Loader />
+      </Container>
     ) : (
       <Container>
-        <Form>
-          <Form.Group inline>
-            <Form.Input placeholder='25세' width={2} size='mini' />
-            <Form.Input placeholder='35세' width={2} size='mini' />
-            <Form.Checkbox label='Top School' />
-          </Form.Group>
-          <Form.Group>
-            <Form.Input placeholder='검색어 (And, Or)' width={4} size='mini' />
-            <Form.Button compact mini>Search</Form.Button>
-          </Form.Group>
-          <br></br>
-          <br></br>
-        </Form>
-        <Dropdown
-          placeholder='Position'
-          fluid multiple selection compact
-          options={this.positionOptions}
-          style={{minWidth:'10em', maxWidth:'25em'}}
-          >
-        </Dropdown>
-        <Button.Group inline compact mini>
-          <this.MailModal />
-          <Button.Or />
-          <this.SMSModal />
-        </Button.Group>
+        <this.MainPage />
         <br></br>
         {this._renderTable()}
+        <this.PeopleModal />
       </Container>
     )
   }

--- a/client/src/components/menu/Sms.js
+++ b/client/src/components/menu/Sms.js
@@ -128,24 +128,9 @@ export default class SMS extends Component {
       <Container>
         <Grid.Row>
           <Grid.Column width={13}>
-            <Breadcrumb>
-              {/* mail/sms 이동하는 별도의 메뉴 */}
-              <Breadcrumb.Section link active>
-                Mail
-              </Breadcrumb.Section>
-              <Breadcrumb.Divider>|</Breadcrumb.Divider>
-              <Breadcrumb.Section link>SMS</Breadcrumb.Section>
-              <Breadcrumb.Divider>|</Breadcrumb.Divider>
-            </Breadcrumb>
-          </Grid.Column>
-          <Grid.Column width={3}>
-            <Breadcrumb>
-              <Breadcrumb.Section link>Follow up</Breadcrumb.Section>
-              <Breadcrumb.Divider>|</Breadcrumb.Divider>
-              <Breadcrumb.Section>
-                <a href="/">새로운 문자</a>
-              </Breadcrumb.Section>
-            </Breadcrumb>
+            <Button compact mini floated='right' color='teal'>
+              Follow Up
+            </Button>
           </Grid.Column>
         </Grid.Row>
 

--- a/client/src/components/menu/Sms.js
+++ b/client/src/components/menu/Sms.js
@@ -1,20 +1,14 @@
-import React, { Component } from 'react';
-import Axios from 'axios';
-import API from '../../util/api';
-import ReactTable from 'react-table';
-import 'react-table/react-table.css';
+import React, { Component } from 'react'
+import Axios from 'axios'
+import API from '../../util/api'
+import Loader from '../../util/Loader'
+import ReactTable from 'react-table'
+import 'react-table/react-table.css'
 import {
   Container,
   Grid,
-  Modal,
-  Divider,
-  Checkbox,
-  Table,
-  Form,
-  Dropdown,
-  Button,
-  Breadcrumb
-} from 'semantic-ui-react';
+  Button
+} from 'semantic-ui-react'
 
 export default class SMS extends Component {
   state = {
@@ -32,12 +26,12 @@ export default class SMS extends Component {
     // peopleData: [],
     clickedData: [],
     mail: `안녕하세요 ㅇㅇㅇ 님, 어제 제안드렸던 Position 에 대해서 어떻게 생각해보셨는지 문의차 다시 메일 드립니다. 간략히 검토후 의향에 대해서 회신 주시면 감사하겠습니다. ㅇㅇㅇ 드림`
-  };
+  }
 
   _renderTable() {
-    const { peopleData } = this.state;
+    const { peopleData } = this.state
 
-    console.log('clicked', this.state.clickedData);
+    console.log('clicked', this.state.clickedData)
     return (
       <ReactTable
         data={peopleData}
@@ -48,9 +42,9 @@ export default class SMS extends Component {
               textAlign: 'center'
             },
             onClick: () => {
-              this.setState({ clickedData: rowInfo.original });
+              this.setState({ clickedData: rowInfo.original })
             }
-          };
+          }
         }}
         columns={[
           {
@@ -95,13 +89,13 @@ export default class SMS extends Component {
         defaultPageSize={15}
         className="-striped -highlight"
       />
-    );
+    )
   }
 
   async componentDidMount() {
     this.setState({
       loading: true
-    });
+    })
     await Axios.post(API.mainTable, {
       // 제대로 된 API 주소 나오면 변경해야 함.
       under_age: 0,
@@ -113,24 +107,26 @@ export default class SMS extends Component {
         this.setState({
           // peopleData: res.data.result,
           loading: false
-        });
+        })
       })
       .catch(err => {
-        console.log(err.response);
-      });
+        console.log(err.response)
+      })
   }
   render() {
-    const { loading } = this.state;
+    const { loading } = this.state
 
     return loading ? (
-      <div>people loading</div>
+      <Loader />
     ) : (
       <Container>
         <Grid.Row>
           <Grid.Column width={13}>
-            <Button compact mini floated='right' color='teal'>
-              Follow Up
-            </Button>
+          <Button 
+            compact mini floated='right' color='teal'
+            icon='send' content='Follow Up'
+            >
+          </Button>
           </Grid.Column>
         </Grid.Row>
 
@@ -138,6 +134,6 @@ export default class SMS extends Component {
         <br />
         {this._renderTable()}
       </Container>
-    );
+    )
   }
 }

--- a/client/src/components/menu/menu.css
+++ b/client/src/components/menu/menu.css
@@ -1,0 +1,3 @@
+.ReactTable .rt-tr:hover .rt-td {
+    background: #008080
+}

--- a/client/src/util/Loader.js
+++ b/client/src/util/Loader.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Loader } from 'semantic-ui-react'
+
+const LoaderExampleTextShorthand = () => (
+  <div>
+    <Loader active inline='centered' size='massive' />
+  </div>
+)
+
+export default LoaderExampleTextShorthand


### PR DESCRIPTION
- breadcrumbs 빼고, mail/sms 에 있는 follow up을 버튼으로 바꿨습니다
- (버튼을 누르면 mail/sms 팝업이 나오도록 후에 만들 예정입니다)
- people 페이지의 form과 버튼의 사이즈를 줄였어요
---
- 이제 people 페이지의 테이블에 있는 후보자 이름을 누르면 상세 이력서로 이동합니다
- people 페이지에 렌더할 컴포넌트들을 MainPage 묶으면서 리팩토링 하였습니다
- 체크버튼이 클릭되면 mail/sms 의 모달 타이틀과 텍스트박스에 후보자 이름이 오토 생성됩니다
- 테이블 로딩 시 보여줄 Loader 를 추가했습니다
- menu CSS 를 추가했습니다. 이제 테이블의 active row 색깔이 변합니다.
- 버튼 UI
- semicolon와 사용하지 않는 imports를 뺐습니다