### PR TITLE
disable delete, edit button when no one selected and add tooltip

### DIFF
--- a/client/src/components/menu/Job.js
+++ b/client/src/components/menu/Job.js
@@ -11,7 +11,8 @@ import {
   Tag,
   Input,
   Button,
-  Icon
+  Icon,
+  Tooltip
 } from 'antd'
 import Highlighter from 'react-highlight-words'
 
@@ -316,7 +317,10 @@ export default class Job extends Component {
         name: record.name
       })
     }
-
+    const { selectedRowKeys } = this.state
+    const hasSelectedOne = selectedRowKeys.length === 1
+    const hasSelectedMultiple = selectedRowKeys.length >= 1
+    const editButtonToolTip = <span>편집을 위해서는 하나만 선택해주세요.</span>
     return (
       <div style={{ marginLeft: '20px' }}>
         <div style={{ marginTop: '16px', width: '85%' }}>
@@ -329,30 +333,50 @@ export default class Job extends Component {
             등록
           </Button>
 
-          <Popconfirm
-            title="Are you sure you want to delete this?"
-            onConfirm={this.handleDeleteConfirm}
-            onCancel={this.handleDeleteCancel}
-            okText="OK"
-            cancelText="Cancel"
-          >
+          {hasSelectedMultiple ? (
+            <Popconfirm
+              title="Are you sure you want to delete this?"
+              onConfirm={this.handleDeleteConfirm}
+              onCancel={this.handleDeleteCancel}
+              okText="OK"
+              cancelText="Cancel"
+              disabled={!hasSelectedMultiple}
+            >
+              <Button
+                type="primary"
+                icon="delete"
+                style={{ marginRight: 5, marginBottom: 16 }}
+                disabled={!hasSelectedMultiple}
+              >
+                삭제
+              </Button>
+            </Popconfirm>
+          ) : (
             <Button
               type="primary"
               icon="delete"
               style={{ marginRight: 5, marginBottom: 16 }}
+              disabled={!hasSelectedMultiple}
             >
               삭제
             </Button>
-          </Popconfirm>
+          )}
 
-          <Button
-            type="primary"
-            icon="edit"
-            onClick={this.showUpdateModal}
-            style={{ marginRight: 5, marginBottom: 16 }}
+          <Tooltip
+            placement="right"
+            title={editButtonToolTip}
+            visible={selectedRowKeys.length > 1}
           >
-            편집
-          </Button>
+            <Button
+              type="primary"
+              icon="edit"
+              onClick={this.showUpdateModal}
+              style={{ marginRight: 5, marginBottom: 16 }}
+              disabled={!hasSelectedOne}
+            >
+              편집
+            </Button>
+          </Tooltip>
         </div>
 
         <this.jobModal />

--- a/client/src/components/menu/People.js
+++ b/client/src/components/menu/People.js
@@ -1074,8 +1074,8 @@ export default class People extends Component {
       }
     })
 
-    const optionList = this.state.positionData.map((position, index) => (
-      <Option value={position.keyword} key={index}>
+    const optionList = this.state.positionData.map(position => (
+      <Option value={position.keyword} key={position.position_id}>
         {`${position.title}    키워드 : ${position.keyword}`}
       </Option>
     ))


### PR DESCRIPTION
- Job에서 아무도 선택하지 않았을때 삭제, 편집 버튼을 사용할 수 있었던 문제 수정(클릭시 오류 발생했었음)
- Job에서 두 명 이상 선택했을 경우 버튼 disabled 되고 한명만 편집 된다고 툴팁 띄워줌. 
- Job에서 삭제버튼이 disabled 됐을땐 Popconfirm 안 뜨도록 수정.
- people에서 option에 key 부여 (근데도 에러 로그 뜨는 건 어쩔 수 없네요. 좀 더 찾아봐야 할듯)