### PR TITLE
correct the different behavior of people & sms, when without selecting

### DIFF
--- a/client/src/components/menu/Sms.js
+++ b/client/src/components/menu/Sms.js
@@ -255,6 +255,21 @@ export default class SMS extends Component {
     await console.log('state', this.state.sms)
     await console.log('selected rows: ', this.state.selectedRowKeys)
     await console.log('preparing to send')
+    if (this.state.selectedRowKeys.length === 0) {
+      try {
+        await Axios.post(API.sendSMS, {
+          user_id: this.props.user_id,
+          rm_code: '',
+          recipient: this.state.sms.receiver,
+          body: this.state.sms.content,
+          position: ''
+        })
+        await console.log(`${this.state.sms.receiver}에 문자를 보냈습니다.`)
+        // await this.resetSelections()
+      } catch (err) {
+        console.log('send one SMS error', err)
+      }
+    }
     if (this.state.selectedRowKeys.length === 1) {
       try {
         await Axios.post(API.sendSMS, {


### PR DESCRIPTION
- people과 sms페이지에서의 sendSMS 함수의 동작 방식이 동일하도록 수정. 
- 여전히, 상모님이 다수에게 직접 핸드폰 번호를 입력해서 보낼려고 시도하는 경우, 현재 sendSms는 입력값과 상관없이 선택한 사람들에게만 sms가 가도록 되어있으므로 사용자의 예상과 다르게 동작할 문제가 존재. 추후 수정할 예정.