### PR TITLE
get candidate email and mobile

### DIFF
--- a/chrome-extension/public/background.js
+++ b/chrome-extension/public/background.js
@@ -1,141 +1,73 @@
 /*global chrome*/
-const tabInfo = { url: null, html: null, candidate: {} };
 
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-  switch (message.action) {
-    case 'popupOpen': {
-      init();
-      break;
-    }
-    default: {
-      console.log('no popup');
-    }
-  }
-});
+// chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+//   switch (message.action) {
+//     case 'popupOpen': {
+//       console.log('popup is open...');
+//       chrome.storage.local.get(['user'], function(response) {
+//         if (!response.user) {
+//           chrome.identity.getProfileUserInfo(function(result) {
+//             validateEmail(result.email);
+//             chrome.storage.local.set({
+//               resumeCount: 0,
+//               mailCount: 0,
+//               smsCount: 0
+//             });
+//           });
+//         }
+//       });
+//       break;
+//     }
+//     default: {
+//       console.log('no popup');
+//     }
+//   }
+// });
 
 chrome.extension.onConnect.addListener(function(port) {
-  port.onMessage.addListener(function(msg) {
+  port.onMessage.addListener(async function(msg) {
     console.log('Received: ' + msg);
-    if (msg === 'Requesting user email address') {
-      chrome.storage.local.get(['user'], function(result) {
-        port.postMessage(result);
+    if (msg === 'Requesting crawling') {
+      let user = '';
+      chrome.storage.local.get(['user'], async function(response) {
+        if (!response.user) {
+          chrome.identity.getProfileUserInfo(async function(result) {
+            await chrome.storage.local.set({
+              resumeCount: 0,
+              mailCount: 0,
+              smsCount: 0
+            });
+            user = await validateEmail(result.email);
+            console.log('user', user);
+          });
+        } else {
+          user = response.user;
+          console.log('user is already logged in.');
+        }
+        getURL(_getValue);
+        getHTML(_getValue);
+        getHistory();
+        crawlCandidate();
+        chrome.storage.local.get(null, function(response) {
+          console.log('sending message');
+          port.postMessage({
+            user: response.user,
+            url: response.url,
+            html: response.html,
+            history: response.history,
+            resumeCount: response.resumeCount,
+            candidate: response.candidate
+          });
+        });
       });
-    }
+    } else if (msg === 'Requesting reset')
+      chrome.storage.local.set({
+        resumeCount: 0,
+        mailCount: 0,
+        smsCount: 0
+      });
   });
 });
-
-async function init() {
-  await getUser();
-  await getURL();
-  await getHTML();
-  await printStorage();
-}
-
-function getUser() {
-  chrome.storage.local.get(null, function(result) {
-    try {
-      if (result && result.user && result.user.check === true) {
-        console.log('user is already logged in');
-        chrome.storage.local.set({ resumeCount: result.resumeCount + 1 });
-        return result.user.user_email;
-      } else {
-        console.log('user is not logged in. calling user check');
-        return chrome.identity.getProfileUserInfo(function(userInfo) {
-          validateEmail(userInfo.email);
-        });
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  });
-}
-
-function getURL() {
-  chrome.tabs.query(
-    {
-      active: true,
-      currentWindow: true
-    },
-    ([currentTab]) => {
-      tabInfo.url = currentTab.url;
-    }
-  );
-}
-function getHTML() {
-  chrome.tabs.executeScript(
-    null,
-    { code: 'var html = document.documentElement.outerHTML; html' },
-    function(html) {
-      tabInfo.html = html;
-    }
-  );
-  parse();
-}
-
-function parse() {
-  if (tabInfo.url && tabInfo.url.includes('saramin')) {
-    runQuery('saramin');
-  } else if (tabInfo.url && tabInfo.url.includes('jobkorea')) {
-    runQuery('jobkorea');
-  } else if (tabInfo.url && tabInfo.url.includes('linkedin')) {
-    sendRequest();
-  }
-}
-
-function runQuery(website) {
-  const query = {
-    saramin:
-      "var mail = document.querySelector('#resume_print_area > div > div.section_profile > div.personal_info.case1 > div.my_data > ul > li.mail > span').innerHTML; var cell = document.querySelector('#resume_print_area > div > div.section_profile > div.personal_info.case1 > div.my_data > ul > li.phone > span > a').innerHTML; var candidate = { mail: mail, cell: cell }; candidate",
-    jobkorea:
-      "var mail = document.querySelector('body > div.resume-view-page > div.resume-view-wrapper > div > div.base.profile > div.container > div > div.info-detail > div:nth-child(1) > div.value').innerHTML; var cell = document.querySelector('body > div.resume-view-page > div.resume-view-wrapper > div > div.base.profile > div.container > div > div.info-detail > div:nth-child(1) > div.value').innerHTML; var candidate = { mail: mail, cell: cell }; candidate"
-  };
-
-  for (let props in query) {
-    if (props === website) {
-      const code = query[props];
-      return chrome.tabs.executeScript(
-        null,
-        {
-          code: code
-        },
-        function(candidate) {
-          tabInfo.candidate = candidate;
-          sendRequest();
-        }
-      );
-    } else {
-      console.log('wrong website!');
-    }
-  }
-}
-
-function sendRequest() {
-  chrome.storage.local.get(['user'], function(result) {
-    const user = result.user;
-    const api = 'http://128.199.203.161:8500/extension/parsing';
-    console.log("before sending request, let's check tabInfo", tabInfo);
-    const input = {
-      user_id: user.user_id,
-      url: tabInfo.url,
-      html: tabInfo.html[0]
-    };
-    const headers = {
-      'Content-Type': 'application/json',
-      'Access-Control-Origin': '*'
-    };
-    fetch(api, {
-      method: 'POST',
-      headers: headers,
-      body: JSON.stringify(input)
-    })
-      .then(response => response.json())
-      // TODO: need to press twice to refresh candidate email / mobile
-      .then(responseJson =>
-        chrome.storage.local.set({ candidate: responseJson })
-      )
-      .catch(error => console.log(error));
-  });
-}
 
 function validateEmail(email) {
   const api = 'http://128.199.203.161:8500/extension/login';
@@ -160,17 +92,82 @@ function validateEmail(email) {
     .catch(error => console.log(error));
 }
 
+async function _getValue(param, value) {
+  console.log({ [param]: value });
+  await chrome.storage.local.set({ [param]: value });
+}
+
+const getURL = async callback => {
+  await chrome.tabs.query(
+    { active: true, currentWindow: true },
+    async ([currentTab]) => {
+      await callback('url', currentTab.url);
+    }
+  );
+};
+
+const getHTML = async callback => {
+  await chrome.tabs.executeScript(
+    null,
+    { code: 'var html = document.documentElement.outerHTML; html' },
+    async function(html) {
+      await callback('html', html[0]);
+    }
+  );
+};
+
+function getHistory() {
+  chrome.storage.local.get(null, async function(response) {
+    const api = 'http://128.199.203.161:8500/extension/view_history';
+    const headers = {
+      'Content-Type': 'application/json',
+      'Access-Control-Origin': '*'
+    };
+    const user = response.user;
+    const url = response.url;
+    const input = {
+      user_id: user.user_id,
+      user_name: user.user_name,
+      url
+    };
+    console.log('history inputs: ', input);
+    const data = await fetch(api, {
+      method: 'POST',
+      headers: headers,
+      body: JSON.stringify(input)
+    });
+    const json = await data.json();
+    chrome.storage.local.set({ history: json });
+  });
+}
+
+const crawlCandidate = async () => {
+  chrome.storage.local.get(null, async function(response) {
+    chrome.storage.local.set({ resumeCount: response.resumeCount + 1 });
+    const api = 'http://128.199.203.161:8500/extension/parsing';
+    const headers = {
+      'Content-Type': 'application/json',
+      'Access-Control-Origin': '*'
+    };
+    const input = {
+      user_id: response.user.user_id,
+      user_name: response.user.user_name,
+      url: response.url,
+      html: response.html
+    };
+    console.log('crawl inputs: ', input);
+    const data = await fetch(api, {
+      method: 'POST',
+      headers: headers,
+      body: JSON.stringify(input)
+    });
+    const json = await data.json();
+    chrome.storage.local.set({ candidate: json });
+    console.log(json);
+    return json;
+  });
+};
+
 // function sleep(ms) {
 //   return new Promise(resolve => setTimeout(resolve, ms));
 // }
-
-function printStorage() {
-  // chrome.storage.local.get(null, function(items) {
-  //   for (let key in items) {
-  //     console.log(key, items[key]);
-  //   }
-  // });
-  chrome.storage.local.get(['candidate'], function(response) {
-    console.log(response.candidate);
-  });
-}


### PR DESCRIPTION
- 파싱 후 받은 response 를 this.state.candidate 에 저장합니다
- 파싱된 이메일과 전화번호를 view 에 보여줍니다
- 조회 버튼을 누르면 후보자에 관한 메모를 보여줍니다
- 입력 버튼을 누르면 후보자에 관한 새 메모를 저장합니다
- 별도의 로그인/로그아웃 기능을 refresh 버튼 기능으로 교체했습니다. 버튼을 누르면 daily count 가 리셋됩니다
---
* 로그인/로그아웃 기능 때문에  3번+ 눌러야 새 후보자의 이메일/전화번호가 view 에 떴었고.. 크롬 익스텐션 팝업 상 state 관리가 번거로워 너무 잔버그가 많았습니다. 그래서 로그인 자체를 없앴습니다! 
* 이제 익스텐션 버튼을 누르면 백그라운드에서 크롤링 api 요청을 보내는 게 아니라, save 버튼을 클릭해야지만 요청이 보내집니다.
* 아직도 2번을 눌러야지 새 후보자의 정보를 긁어옵니다 ㅋㅋ 콘솔 찍어보니 getHistory 와 crawlCandidate 에 old inputs 가 들어갑니다..


