### PR TITLE
fix a problem that contains a persons name, not a number, in the recipents form

### DIFF
--- a/client/src/components/forms/SmsForm.js
+++ b/client/src/components/forms/SmsForm.js
@@ -165,6 +165,8 @@ class SmsForm extends React.Component {
         ))
     }
 
+    console.log('selectedRows[0]', selectedRows[0])
+
     let smsName
     // let positionRule
     let smsContent = ''
@@ -175,7 +177,7 @@ class SmsForm extends React.Component {
       // positionRule = [{ required: false }]
       recipientPlaceholder = '한 명만 보낼 수 있습니다. 폰 번호를 입력해주세요.'
     } else {
-      smsName = receivers || selectedRows[0].name
+      smsName = receivers || selectedRows[0].mobile
       // positionRule = [
       //   { required: true, message: 'Please fill in the content.' }
       // ]

--- a/client/src/components/menu/People.js
+++ b/client/src/components/menu/People.js
@@ -320,25 +320,22 @@ class People extends Component {
   }
 
   smsModal = () => {
-    // let receiversMobileNumber =
-    //   this.state.selectedRows.length > 1
-    //     ? this.state.selectedRows.map((row, index) => row.mobile).join(',')
-    //     : null
-
-    let title
+    let title = ''
     if (this.state.selectedRows.length === 0) {
       title = 'SMS'
     } else {
-      this.state.selectedRows.length > 1
-        ? (title = `SMS ${this.state.selectedRows[0].mobile} 외`)
-        : (title = `SMS ${this.state.selectedRows[0].mobile}`)
+      title += 'SMS'
+      this.state.selectedRows.forEach((row, index) => {
+        title += ` ${this.state.selectedRows[index].name} ${
+          this.state.selectedRows[index].mobile
+        }`
+      })
     }
 
     return (
       <div>
         <Modal
           title={title}
-          // title="SMS"
           visible={this.state.smsVisible}
           onOk={this.handleSmsOk}
           onCancel={this.handleSmsCancel}

--- a/client/src/components/menu/Sms.js
+++ b/client/src/components/menu/Sms.js
@@ -290,19 +290,10 @@ export default class SMS extends Component {
   // }
 
   smsModal = () => {
-    let title
-    if (this.state.selectedRows.length === 0) {
-      title = 'SMS'
-    } else {
-      this.state.selectedRows.length > 1
-        ? (title = `SMS ${this.state.selectedRows[0].mobile} 외`)
-        : (title = `SMS ${this.state.selectedRows[0].mobile}`)
-    }
-
     return (
       <div>
         <Modal
-          title={title}
+          title="SMS"
           visible={this.state.visible}
           onOk={this.handleOk}
           onCancel={this.handleCancel}


### PR DESCRIPTION
- people에서 sms 보낼 때, 수신자 번호가 아니라 이름이 들어가던 문제 수정
- people에서 여러 명에게 문자 보낼 때, SMS 타이틀에 이름과 번호가 같이 표시되도록 수정