### PR TITLE
keep resume cache

### DIFF
--- a/chrome-extension/public/background.js
+++ b/chrome-extension/public/background.js
@@ -1,11 +1,11 @@
 /*global chrome*/
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
   switch (message.action) {
     case 'popupOpen': {
       console.log('popup is open...');
-      chrome.storage.local.get(['user'], function(response) {
+      chrome.storage.local.get(['user'], response => {
         if (!response.user) {
-          chrome.identity.getProfileUserInfo(function(result) {
+          chrome.identity.getProfileUserInfo(result => {
             validateEmail(result.email);
             chrome.storage.local.set({
               resumeCount: 0,
@@ -16,6 +16,8 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
           });
         }
       });
+      await getURL();
+      await loadCandidate();
       break;
     }
     default: {
@@ -37,13 +39,15 @@ chrome.extension.onConnect.addListener(function(port) {
       } catch (error) {
         console.log(error);
       }
+      await records();
       await compileMessage(myPort);
     } else if (msg === 'Requesting reset')
       chrome.storage.local.set(
         {
           resumeCount: 0,
           mailCount: 0,
-          smsCount: 0
+          smsCount: 0,
+          records: []
         },
         response => console.log(response)
       );
@@ -77,6 +81,27 @@ const getURL = () => {
   return new Promise((resolve, reject) => {
     chrome.tabs.query({ active: true, currentWindow: true }, ([currentTab]) => {
       resolve(chrome.storage.local.set({ url: currentTab.url }));
+    });
+  });
+};
+
+const loadCandidate = () => {
+  console.log('loading candidate');
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(['records', 'url'], response => {
+      const candidateUrl = response.url.substring(28);
+      console.log('candidateUrl', candidateUrl);
+      for (let i = 0; i < response.records.length; i++) {
+        let record = response.records[i];
+        let candidateId = record.candidate.rm_code.substring(13);
+        if (candidateUrl.includes(candidateId)) {
+          console.log(record.candidate);
+          resolve(chrome.storage.local.set({ saved: record.candidate }));
+          break;
+        } else {
+          console.log('no it does not include');
+        }
+      }
     });
   });
 };
@@ -153,6 +178,20 @@ const crawlCandidate = async () => {
   });
 };
 
+const records = () => {
+  chrome.storage.local.get({ records: [], candidate: {} }, function(result) {
+    const records = result.records;
+    if (result.candidate.code === 200) {
+      records.push({ candidate: result.candidate.result });
+      chrome.storage.local.set({ records: records }, function() {
+        chrome.storage.local.get('records', function(result) {
+          console.log(result.records);
+        });
+      });
+    }
+  });
+};
+
 const compileMessage = myPort => {
   let message = {};
   return new Promise((resolve, reject) => {
@@ -164,7 +203,9 @@ const compileMessage = myPort => {
           html: response.html,
           history: response.history,
           resumeCount: response.resumeCount,
-          candidate: response.candidate
+          candidate: response.candidate.result,
+          records: response.records,
+          saved: response.saved
         };
         console.log(message);
         myPort.postMessage(message);

--- a/chrome-extension/src/App.js
+++ b/chrome-extension/src/App.js
@@ -41,21 +41,23 @@ class App extends Component {
         }으로 제안드리오니 메일 검토를 부탁드리겠습니다. 감사합니다.`,
         sign: '\n커리어셀파 강상모 드림. 010-3929-7682'
       },
-      fetchingUserData: false,
       fetchingCrawlingData: false,
       validated: false,
       user: {},
       url: '',
-      records: []
+      records: [],
+      mailList: [],
+      mailKey: 0
     };
   }
 
   componentDidMount() {
     this.fetchUser();
-    this.fetchPosition();
     this.getResumeCount();
     this.getCount('mailCount');
     this.getCount('smsCount');
+    this.fetchPosition();
+    this.loadExistingCandidateData();
   }
 
   fetchUser = async () => {
@@ -63,8 +65,7 @@ class App extends Component {
       await chrome.storage.local.get(['user', 'saved', 'url'], response => {
         if (response.user && response.user.check === true) {
           this.setState({
-            user: response.user,
-            candidate: response.saved
+            user: response.user
           });
         }
       });
@@ -144,6 +145,91 @@ class App extends Component {
     }
   };
 
+  fetchMail = async () => {
+    try {
+      const mails = await Axios.post(Api.getMail, {
+        user_id: this.state.user.user_id,
+        rm_code: this.state.candidate.rm_code,
+        email: this.state.candidate.email
+      });
+      this.setState(prevState => ({
+        mailList: [...prevState.mailList, mails.data.result]
+      }));
+    } catch (err) {
+      alert(err);
+    }
+  };
+
+  nextMail = async () => {
+    try {
+      const { mailKey, mailList } = this.state;
+      if (mailKey === 0 && mailList[0][0]) {
+        const { body, client, position } = mailList[0][0];
+        this.setState(prevState => ({
+          selectedPosition: position,
+          mail: {
+            title: `${client} | ${position}`,
+            content: body,
+            sign: `\n커리어셀파 헤드헌터 강상모 \n+82 010 3929 7682 \nwww.careersherpa.co.kr`
+          },
+          mailKey: prevState.mailKey + 1
+        }));
+        alert('메일을 불러왔습니다');
+      } else if (mailKey > 0 && mailList[0][mailKey]) {
+        const { body, client, position } = mailList[0][mailKey];
+        this.setState(prevState => ({
+          selectedPosition: position,
+          mail: {
+            title: `${client} | ${position}`,
+            content: body,
+            sign: `\n커리어셀파 헤드헌터 강상모 \n+82 010 3929 7682 \nwww.careersherpa.co.kr`
+          },
+          mailKey: prevState.mailKey + 1
+        }));
+        alert('이메일을 불러왔습니다');
+      } else {
+        alert('더 이상 메일이 없습니다');
+      }
+    } catch (err) {
+      alert(err);
+    }
+  };
+
+  priorMail = async () => {
+    try {
+      const { mailKey, mailList } = this.state;
+      if (mailKey === 0 && mailList[0][0]) {
+        const { body, client, position } = mailList[0][0];
+        this.setState(prevState => ({
+          selectedPosition: position,
+          mail: {
+            title: `${client} | ${position}`,
+            content: body,
+            sign: `\n커리어셀파 헤드헌터 강상모 \n+82 010 3929 7682 \nwww.careersherpa.co.kr`
+          }
+        }));
+        alert('메일을 불러왔습니다');
+      }
+      if (mailKey > 0 && mailList[0][mailKey - 1]) {
+        const { body, client, position } = mailList[0][mailKey - 1];
+        this.setState(prevState => ({
+          selectedPosition: position,
+          mail: {
+            title: `${client} | ${position}`,
+            content: body,
+            sign: `\n커리어셀파 헤드헌터 강상모 \n+82 010 3929 7682 \nwww.careersherpa.co.kr`
+          },
+          mailKey: prevState.mailKey - 1
+        }));
+        alert('이메일을 불러왔습니다');
+      } else {
+        alert('더 이상 메일이 없습니다');
+      }
+    } catch (err) {
+      alert(err);
+    }
+  };
+
   mailSubmit = event => {
     const form = event.currentTarget;
     if (form.checkValidity() === false) {
@@ -151,16 +237,9 @@ class App extends Component {
       event.stopPropagation();
     } else {
       event.preventDefault();
-      this.setState({ validated: true });
+      this.setState({ validated: true, mailKey: 0 });
       this.sendMail();
     }
-  };
-
-  fetchMail = () => {
-    Axios.post(Api.getMail, {
-      user_id: this.state.user.user_id,
-      rm_code: this.state.candidate.rm_code
-    });
   };
 
   sendMail = () => {
@@ -247,6 +326,19 @@ class App extends Component {
     });
   };
 
+  loadExistingCandidateData = () => {
+    var port = chrome.extension.connect({
+      name: 'Load Existing Candidate Data Communication'
+    });
+    port.postMessage('Requesting existing candidate data');
+    port.onMessage.addListener(saved => {
+      this.setState({
+        candidate: saved,
+        ratings: saved.rate
+      });
+    });
+  };
+
   reset = () => {
     var port = chrome.extension.connect({
       name: 'Resetting Communication'
@@ -270,6 +362,7 @@ class App extends Component {
         const sortRatings = response.candidate.rate.sort((a, b) => {
           return b.score - a.score;
         });
+        this.fetchMail();
         this.setState({
           user: response.user,
           history: response.history,
@@ -281,27 +374,7 @@ class App extends Component {
         });
       } else {
         alert('Unauthorized user');
-        this.setState({ fetchingUserData: false, fetchingCrawlingData: false });
-      }
-    });
-  };
-
-  requestUserIdentity = () => {
-    this.setState({ fetchingUserData: true });
-    var port = chrome.extension.connect({
-      name: 'User Email Communication'
-    });
-    port.postMessage('Requesting user info');
-    port.onMessage.addListener(response => {
-      if (response.user && response.user.check === true) {
-        this.setState({
-          user: response.user,
-
-          fetchingUserData: false
-        });
-      } else {
-        alert('Unauthorized user');
-        this.setState({ fetchingUserData: false });
+        this.setState({ fetchingCrawlingData: false });
       }
     });
   };
@@ -635,11 +708,23 @@ class App extends Component {
                   </Form.Group>
                   <Form.Group as={Row}>
                     <Col sm={9} />
-                    <Button column sm={2} size="sm" variant="outline-warning">
+                    <Button
+                      onClick={this.priorMail}
+                      column
+                      sm={2}
+                      size="sm"
+                      variant="outline-warning"
+                    >
                       <i className="fas fa-arrow-left" />
                     </Button>
                     <Col sm={2}>
-                      <Button column sm={2} size="sm" variant="outline-warning">
+                      <Button
+                        onClick={this.nextMail}
+                        column
+                        sm={2}
+                        size="sm"
+                        variant="outline-warning"
+                      >
                         <i className="fas fa-arrow-right" />
                       </Button>
                     </Col>

--- a/chrome-extension/src/App.js
+++ b/chrome-extension/src/App.js
@@ -44,7 +44,9 @@ class App extends Component {
       fetchingUserData: false,
       fetchingCrawlingData: false,
       validated: false,
-      user: {}
+      user: {},
+      url: '',
+      records: []
     };
   }
 
@@ -58,10 +60,11 @@ class App extends Component {
 
   fetchUser = async () => {
     try {
-      await chrome.storage.local.get(['user'], response => {
+      await chrome.storage.local.get(['user', 'saved', 'url'], response => {
         if (response.user && response.user.check === true) {
           this.setState({
-            user: response.user
+            user: response.user,
+            candidate: response.saved
           });
         }
       });
@@ -264,13 +267,13 @@ class App extends Component {
     port.postMessage('Requesting crawling');
     port.onMessage.addListener(response => {
       if (response.user && response.user.check === true) {
-        const sortRatings = response.candidate.result.rate.sort((a, b) => {
+        const sortRatings = response.candidate.rate.sort((a, b) => {
           return b.score - a.score;
         });
         this.setState({
           user: response.user,
           history: response.history,
-          candidate: response.candidate.result,
+          candidate: response.candidate,
           ratings: sortRatings,
 
           fetchingCrawlingData: false,

--- a/chrome-extension/src/App.js
+++ b/chrome-extension/src/App.js
@@ -161,6 +161,7 @@ class App extends Component {
   };
 
   nextMail = async () => {
+    alert(JSON.stringify(this.state.mailList));
     try {
       const { mailKey, mailList } = this.state;
       if (mailKey === 0 && mailList[0][0]) {
@@ -336,6 +337,7 @@ class App extends Component {
         candidate: saved,
         ratings: saved.rate
       });
+      this.fetchMail();
     });
   };
 


### PR DESCRIPTION
* 유저가 스크랩 할 때마다 레쥬메 정보를 cache 합니다.
* 익스텐션 실행 시 탭의 url 를 대조해서 cache 확인 후, 후보자의 정보를 view 에 띄어줍니다. 같은 후보자의 정보를 중복 크롤링 요청하지 않아도 됩니다.
* 익스텐션을 실행하면 cache 에 있는 후보자에게 보냈던 메일들을 불러옵니다.
* 좌우 버튼을 사용하면 과거 메시지로 이동합니다.
* 불필요한 함수들을 삭제했습니다.